### PR TITLE
B34 add table constraints

### DIFF
--- a/models/bookmark.go
+++ b/models/bookmark.go
@@ -1,11 +1,8 @@
 package models
 
 type Bookmark struct {
-
-	UserRefer  uint
-	UserId  Users `gorm:"foreignKey:UserRefer"`
-
-	LocationId    uint
-	Location      Location `gorm:"foreignKey:LocationId"`
-	
+	UserRefer  uint     `gorm: not null; default:null`
+	UserId     Users    `gorm:"foreignKey:UserRefer"`
+	LocationId uint     `gorm: not null; default:null`
+	Location   Location `gorm:"foreignKey:LocationId"`
 }

--- a/models/location-feature.go
+++ b/models/location-feature.go
@@ -1,24 +1,24 @@
 package models
 
 type LocationFeature struct {
-	LocationId           uint
+	LocationId           uint     `gorm: not null; default:null`
 	Location             Location `gorm:"foreignKey:LocationId"`
-	WiFi                 bool
-	WaterFountain        bool
-	PowerSockets         bool
-	Noisy                bool
-	Food                 bool
-	Beverages            bool
-	Toilets              bool
-	WheelchairAccess     bool
-	DiasabledToilets     bool
-	GenderNeutralToilets bool
-	FreeParking          bool
-	PaidParking          bool
-	PetFriendly          bool
-	Vegetarian           bool
-	Vegan                bool
-	OutdoorSeating       bool
-	PhoneSignal          bool
-	NaturalLight         bool
+	WiFi                 bool     `gorm: type:bool; default:false`
+	WaterFountain        bool     `gorm: type:bool; default:false`
+	PowerSockets         bool     `gorm: type:bool; default:false`
+	Noisy                bool     `gorm: type:bool; default:false`
+	Food                 bool     `gorm: type:bool; default:false`
+	Beverages            bool     `gorm: type:bool; default:false`
+	Toilets              bool     `gorm: type:bool; default:false`
+	WheelchairAccess     bool     `gorm: type:bool; default:false`
+	DiasabledToilets     bool     `gorm: type:bool; default:false`
+	GenderNeutralToilets bool     `gorm: type:bool; default:false`
+	FreeParking          bool     `gorm: type:bool; default:false`
+	PaidParking          bool     `gorm: type:bool; default:false`
+	PetFriendly          bool     `gorm: type:bool; default:false`
+	Vegetarian           bool     `gorm: type:bool; default:false`
+	Vegan                bool     `gorm: type:bool; default:false`
+	OutdoorSeating       bool     `gorm: type:bool; default:false`
+	PhoneSignal          bool     `gorm: type:bool; default:false`
+	NaturalLight         bool     `gorm: type:bool; default:false`
 }

--- a/models/location.go
+++ b/models/location.go
@@ -1,14 +1,14 @@
 package models
 
 type Location struct {
-	LocationID   uint `gorm:"primaryKey"`
-	LocationName string
-	Address      string
-	Postcode     string
-	Longitude    float32
-	Latitude     float32
-	Condition    string
-	ImgUrl       string
-	CreatedBy    uint
-	Users        Users `gorm:"foreignKey:CreatedBy"`
+	LocationID   uint    `gorm:"primaryKey"`
+	LocationName string  `gorm:"not null; default:null"`
+	Address      string  `gorm:"not null; default:null"`
+	Postcode     string  `gorm:"not null; default:null"`
+	Longitude    float32 `gorm:"not null; default:null"`
+	Latitude     float32 `gorm:"not null; default:null"`
+	Condition    string  `gorm:"not null; default:null"`
+	ImgUrl       string  `gorm:"not null; default:null"`
+	CreatedBy    uint    `gorm:"not null; default:null"`
+	Users        Users   `gorm:"foreignKey:CreatedBy"`
 }

--- a/models/review.go
+++ b/models/review.go
@@ -3,14 +3,14 @@ package models
 import "time"
 
 type Review struct {
-	UserRefer  uint
-	LocationRefer uint
-	ReviewId	uint	`gorm:"primaryKey"`
-	CreatedAt	time.Time
-	UserId  Users `gorm:"foreignKey:UserRefer"`
-	LocationId	Location `gorm:"foreignKey:LocationRefer"`
-	VisitDate string
-	StarRating int
+	UserRefer     uint `gorm:"not null; default:null"`
+	LocationRefer uint `gorm:"not null; default:null"`
+	ReviewId      uint `gorm:"primaryKey"`
+	CreatedAt     time.Time
+	UserId        Users    `gorm:"foreignKey:UserRefer; not null; default:null"`
+	LocationId    Location `gorm:"foreignKey:LocationRefer; not null; default:null"`
+	VisitDate     string   `gorm:"not null; default:null"`
+	StarRating    int      `gorm:"not null; default:null"`
 	// Another ticket to handle the range of the star rating
-	ReviewBody string
+	ReviewBody string `gorm:"not null; default:null"`
 }

--- a/models/user-preference.go
+++ b/models/user-preference.go
@@ -1,24 +1,24 @@
 package models
 
 type UserPreference struct {
-	UserRefer            int
+	UserRefer            int   `gorm: not null; default:null`
 	Users                Users `gorm:"foreignKey:UserRefer"`
-	WiFi                 bool
-	WaterFountain        bool
-	PowerSockets         bool
-	Noisy                bool
-	Food                 bool
-	Beverages            bool
-	Toilets              bool
-	WheelchairAccess     bool
-	DiasabledToilets     bool
-	GenderNeutralToilets bool
-	FreeParking          bool
-	PaidParking          bool
-	PetFriendly          bool
-	Vegetarian           bool
-	Vegan                bool
-	OutdoorSeating       bool
-	PhoneSignal          bool
-	NaturalLight         bool
+	WiFi                 bool  `gorm: type:bool; default:false`
+	WaterFountain        bool  `gorm: type:bool; default:false`
+	PowerSockets         bool  `gorm: type:bool; default:false`
+	Noisy                bool  `gorm: type:bool; default:false`
+	Food                 bool  `gorm: type:bool; default:false`
+	Beverages            bool  `gorm: type:bool; default:false`
+	Toilets              bool  `gorm: type:bool; default:false`
+	WheelchairAccess     bool  `gorm: type:bool; default:false`
+	DiasabledToilets     bool  `gorm: type:bool; default:false`
+	GenderNeutralToilets bool  `gorm: type:bool; default:false`
+	FreeParking          bool  `gorm: type:bool; default:false`
+	PaidParking          bool  `gorm: type:bool; default:false`
+	PetFriendly          bool  `gorm: type:bool; default:false`
+	Vegetarian           bool  `gorm: type:bool; default:false`
+	Vegan                bool  `gorm: type:bool; default:false`
+	OutdoorSeating       bool  `gorm: type:bool; default:false`
+	PhoneSignal          bool  `gorm: type:bool; default:false`
+	NaturalLight         bool  `gorm: type:bool; default:false`
 }


### PR DESCRIPTION
add not null constraints to tables as well as default to false for preference tables (i.e. only have to put in request body features a location has or preferences a user has)